### PR TITLE
Openshift compilation test

### DIFF
--- a/optaplanner-openshift-worker-rostering-gwtui/pom.xml
+++ b/optaplanner-openshift-worker-rostering-gwtui/pom.xml
@@ -50,9 +50,10 @@
           	<arg>-XdisableUpdateCheck</arg>
           </compilerArgs>
           <!-- Avoid crash "error code 137" on OpenShift? -->
-          <!-- 
-          <jvmArgs>-Xmx300m</jvmArgs>
-           -->
+          <jvmArgs>
+          	 <arg>-Xmx300m</arg>
+          </jvmArgs>
+          <localWorkers>1</localWorkers>
         </configuration>
       </plugin>
     </plugins>

--- a/optaplanner-openshift-worker-rostering-gwtui/pom.xml
+++ b/optaplanner-openshift-worker-rostering-gwtui/pom.xml
@@ -46,9 +46,13 @@
         <configuration>
           <moduleName>org.optaplanner.openshift.workerrostering.gwtui.WorkerRosteringWebapp</moduleName>
           <!-- Remove warnings that only appear on OpenShift -->
-          <compilerArgs>-XdisableUpdateCheck</compilerArgs>
+          <compilerArgs>
+          	<arg>-XdisableUpdateCheck</arg>
+          </compilerArgs>
           <!-- Avoid crash "error code 137" on OpenShift? -->
+          <!-- 
           <jvmArgs>-Xmx300m</jvmArgs>
+           -->
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Limiting the memory of the compiler to -Xmx300m and setting the localWorker to 1 seems to keep the process within the OpenShift Online instance limits.