### PR TITLE
Upped max-memory for GWT compiler.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
               <!-- Avoid crash "error code 137" on OpenShift -->
               <localWorkers>1</localWorkers>
               <jvmArgs>
-                 <arg>-Xmx300m</arg>
+                 <arg>-Xmx386m</arg>
               </jvmArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
We need to give the GWT compiler a bit more memory. This build does work on my OpenShift Online instance (with my BuildConfig). Let's merge this one first, I'll add the OpenShit template as part of issue #3 .